### PR TITLE
set cookies when use --host

### DIFF
--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,18 +1,19 @@
 import { redirect } from "@sveltejs/kit";
 import type { Actions } from "./$types";
+import {dev} from "$app/environment";
 
 export const actions: Actions = {
-	setTheme: async ({ url, cookies }) => {
-		const theme = url.searchParams.get("theme");
-		const redirectTo = url.searchParams.get("redirectTo");
-
-		if (theme) {
-			cookies.set("colortheme", theme, {
-				path: "/",
-				maxAge: 60 * 60 * 24 * 365,
-			});
-		}
-
-		throw redirect(303, redirectTo ?? "/");
-	},
+    setTheme: async ({ url, cookies }) => {
+        const theme = url.searchParams.get("theme");
+        const redirectTo = url.searchParams.get("redirectTo");
+        if (theme) {
+            await cookies.set("colortheme", theme, {
+                path: "/",
+                sameSite: 'lax',
+                maxAge: 60 * 60 * 24 * 365,
+                secure: !dev
+            });
+        }
+        throw redirect(303, redirectTo ?? "/");
+    },
 };


### PR DESCRIPTION
When we use --host to run dev server and use our host network to access without secure and samesite it's not going to set cookies to host. So, use with them.