### PR TITLE
unable to set cookies when secure is not provided

### DIFF
--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,18 +1,19 @@
 import { redirect } from "@sveltejs/kit";
 import type { Actions } from "./$types";
+import {dev} from "$app/environment";
 
 export const actions: Actions = {
-	setTheme: async ({ url, cookies }) => {
-		const theme = url.searchParams.get("theme");
-		const redirectTo = url.searchParams.get("redirectTo");
-
-		if (theme) {
-			cookies.set("colortheme", theme, {
-				path: "/",
-				maxAge: 60 * 60 * 24 * 365,
-			});
-		}
-
-		throw redirect(303, redirectTo ?? "/");
-	},
+    setTheme: async ({ url, cookies }) => {
+        const theme = url.searchParams.get("theme");
+        const redirectTo = url.searchParams.get("redirectTo");
+        if (theme) {
+            await cookies.set("colortheme", theme, {
+                path: "/",
+                sameSite: 'lax',
+                maxAge: 60 * 60 * 24 * 365,
+                secure: !dev
+            });
+        }
+        throw redirect(303, redirectTo ?? "/");
+    },
 };


### PR DESCRIPTION
When we use --host to expose our dev server to local network set cookies without secure will not work. So we need to add
```js
import {dev} from "$app/environment";

await cookies.set("colortheme", theme, {
                path: "/",
                sameSite: 'lax',
                maxAge: 60 * 60 * 24 * 365,
                secure: !dev
            });
```

I'm also using sameSite for best practices but this is upto your needs.